### PR TITLE
Remove Chapel 2.0 hotfix, use `latest` image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,6 @@
   },
   "features": {
   },
-  "postCreateCommand": "awk 'NR==1613 {$0=\"        if not ls.use_resolver:\"} 1' /opt/chapel/tools/chpl-language-server/src/chpl-language-server.py > /opt/chapel/tools/chpl-language-server/src/chpl-language-server.py.tmp && cat /opt/chapel/tools/chpl-language-server/src/chpl-language-server.py.tmp > /opt/chapel/tools/chpl-language-server/src/chpl-language-server.py",
   "customizations": {
     "codespaces": {
       "openFiles": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "chapel/chapel-gasnet:2.6.0",
+  "image": "chapel/chapel-gasnet:latest",
   "containerEnv": {
     "CHPL_COMM": "none",
   },


### PR DESCRIPTION
Remove the awk command bug hotfix that was applied for Chapel 2.0 in https://github.com/chapel-lang/chapel-hello-world/commit/11f2a7130b463e0af86518604b1b019c8d0b59c4, which is now stale and no-op.

With this, we can also switch back to using the `latest` tagged image from Dockerhub, rather than explicitly specifying a version which must be bumped; this originated in https://github.com/chapel-lang/chapel-hello-world/commit/b256421ed31d0f3ab3ced60c1aeb9a75a014f16c to avoid breaking the hotfix.

[reviewer info placeholder]