### PR TITLE
Open rendered readme in codespaces by default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
   "customizations": {
     "codespaces": {
       "openFiles": [
+        "README.md",
         "hello.chpl"
       ]
     },
@@ -17,6 +18,10 @@
       ],
       "settings": {
         "chapel.CHPL_HOME": "/opt/chapel",
+        "workbench.startupEditor": "readme",
+        "workbench.editorAssociations": {
+          "README.md": "vscode.markdown.preview.editor"
+        }
       }
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,13 +5,7 @@
   },
   "features": {
   },
-  "postAttachCommand": "code README.md",
   "customizations": {
-    "codespaces": {
-      "openFiles": [
-        "hello.chpl"
-      ]
-    },
     "vscode": {
       "extensions": [
         "chpl-hpe.chapel-vscode"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,10 +5,10 @@
   },
   "features": {
   },
+  "postAttachCommand": "code README.md",
   "customizations": {
     "codespaces": {
       "openFiles": [
-        "README.md",
         "hello.chpl"
       ]
     },


### PR DESCRIPTION
Use `workbench.startupEditor` and `editorAssociations` settings to
automatically open `README.md` in rendered Markdown preview when a
Codespace starts. Remove the `codespaces.openFiles` directive to
avoid overriding the editor association.
This means we don't open `hello.chpl` by default but that is acceptable and helps keep the rest of the changes cleaner.
