### PR TITLE
Update README to focus on Codespace usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,19 @@
 
 [Chapel](https://github.com/chapel-lang/chapel/) is a programming language for productive parallel computing. This repository is a simple starting point for Chapel in GitHub Codespaces, with runnable examples in [examples/](examples).
 
+> **Not in a Codespace yet?** See [Using a Codespace](#using-a-codespace) below to get started.
+
 > ⚠️ **Warning:** Codespaces runs in a virtualized environment with shared hardware and a modest core count. Performance and available parallelism in Codespaces are not representative of what you should expect on a native Chapel installation.
+
+## Compile And Run With The Run Button In Codespaces VS Code
+
+1. Open [hello.chpl](hello.chpl).
+2. Wait for the Chapel extension and language tools to finish loading in Codespaces.
+3. Click the Run button in the editor (top right) once to compile the code, and once more to run the current file.
+
+Note: The Run button does not support multi-locale (distributed) programs. Use the [terminal](#compile-and-run-in-the-terminal) for those.
+
+If the Run button does not appear right away, wait a bit longer and reopen the `.chpl` file.
 
 ## Compile And Run In The Terminal
 
@@ -31,7 +43,8 @@ CHPL_COMM=gasnet chpl examples/hello4-datapar-dist.chpl
 ./hello4-datapar-dist -nl 2
 ```
 
-Or export once per shell and compile as usual:
+To avoid having to include CHPL_COMM in each compilation command, you can export it (you need to do this once per shell session). After this, you can compile as usual:
+
 
 ```bash
 export CHPL_COMM=gasnet
@@ -41,10 +54,17 @@ chpl examples/hello4-datapar-dist.chpl
 
 ## Learn More And Try More Programs
 
-You can copy in additional examples from Chapel Primers or Chapel tutorial/example programs to explore more language features.
+To explore more language features or play further, you can copy in examples from [Chapel Primers](https://chapel-lang.org/docs/primers/) or a prior tutorial. The following links are also helpful:
+
 
 - [Learning Chapel](https://chapel-lang.org/learning.html)
 - [Chapel Primers](https://chapel-lang.org/docs/primers/)
 - [Chapel tutorial examples](https://github.com/chapel-lang/chapel/tree/main/test/exercises/Oct2023tutorial)
 - [Multilocale Chapel Execution](https://chapel-lang.org/docs/usingchapel/multilocale.html)
 - [Download Chapel](https://chapel-lang.org/download.html)
+
+## Using a Codespace
+
+This repository includes a `devcontainer.json` file, making it usable from GitHub Codespaces. When viewing this repository from GitHub's UI, click **Use this template > Open in a codespace** to get started. Or use the direct link: https://codespaces.new/chapel-lang/chapel-hello-world
+
+The codespace includes the Visual Studio Code extension for Chapel, and tools such as [`chpl-language-server`](https://chapel-lang.org/docs/main/tools/chpl-language-server/chpl-language-server.html) and [`chplcheck`](https://chapel-lang.org/docs/main/tools/chplcheck/chplcheck.html).

--- a/README.md
+++ b/README.md
@@ -1,20 +1,32 @@
 # 'Hello, world!' in Chapel
 
-[Chapel](https://github.com/chapel-lang/chapel/) is a programming language for productive parallel computing. This repository is a simple starting point for Chapel in GitHub Codespaces, with runnable examples in [examples/](examples).
+[Chapel](https://github.com/chapel-lang/chapel/) is a programming language
+for productive parallel computing. This repository is a simple starting
+point for Chapel in GitHub Codespaces, with runnable examples in
+[examples/](examples).
 
-> **Not in a Codespace yet?** See [Using a Codespace](#using-a-codespace) below to get started.
+> **Not in a Codespace yet?** See [Using a Codespace](#using-a-codespace)
+below to get started.
 
-> ⚠️ **Warning:** Codespaces runs in a virtualized environment with shared hardware and a modest core count. Performance and available parallelism in Codespaces are not representative of what you should expect on a native Chapel installation.
+> ⚠️ **Warning:** Codespaces runs in a virtualized environment with shared
+hardware and a modest core count. Performance and available parallelism in
+Codespaces are not representative of what you should expect on a native
+Chapel installation.
 
 ## Compile And Run With The Run Button In Codespaces VS Code
 
 1. Open [hello.chpl](hello.chpl).
-2. Wait for the Chapel extension and language tools to finish loading in Codespaces.
-3. Click the Run button in the editor (top right) once to compile the code, and once more to run the current file.
+2. Wait for the Chapel extension and language tools to finish loading in
+   Codespaces.
+3. Click the Run button in the editor (top right) once to compile the code,
+   and once more to run the current file.
 
-Note: The Run button does not support multi-locale (distributed) programs. Use the [terminal](#compile-and-run-in-the-terminal) for those.
+**Note:** The Run button does not support multi-locale (distributed)
+programs.
+Use the [terminal](#compile-and-run-in-the-terminal) for those.
 
-If the Run button does not appear right away, wait a bit longer and reopen the `.chpl` file.
+If the Run button does not appear right away, wait a bit longer and reopen
+the `.chpl` file.
 
 ## Compile And Run In The Terminal
 
@@ -43,7 +55,9 @@ CHPL_COMM=gasnet chpl examples/hello4-datapar-dist.chpl
 ./hello4-datapar-dist -nl 2
 ```
 
-To avoid having to include `CHPL_COMM` in each compilation command, you can export it (you need to do this once per shell session). After this, you can compile as usual:
+To avoid having to include `CHPL_COMM` in each compilation command, you can
+export it (you need to do this once per shell session). After this, you can
+compile as usual:
 
 
 ```bash
@@ -54,7 +68,9 @@ chpl examples/hello4-datapar-dist.chpl
 
 ## Learn More And Try More Programs
 
-To explore more language features or play further, you can copy in examples from [Chapel Primers](https://chapel-lang.org/docs/primers/) or a prior tutorial. The following links are also helpful:
+To explore more language features or play further, you can copy in examples
+from [Chapel Primers](https://chapel-lang.org/docs/primers/) or a prior
+tutorial. The following links are also helpful:
 
 
 - [Learning Chapel](https://chapel-lang.org/learning.html)
@@ -65,6 +81,12 @@ To explore more language features or play further, you can copy in examples from
 
 ## Using a Codespace
 
-This repository includes a `devcontainer.json` file, making it usable from GitHub Codespaces. When viewing this repository from GitHub's UI, click **Use this template > Open in a codespace** to get started. Or use the direct link: https://codespaces.new/chapel-lang/chapel-hello-world
+This repository includes a `devcontainer.json` file, making it usable from
+GitHub Codespaces. When viewing this repository from GitHub's UI, click
+**Use this template > Open in a codespace** to get started. Or use the
+direct link: https://codespaces.new/chapel-lang/chapel-hello-world
 
-The codespace includes the Visual Studio Code extension for Chapel, and tools such as [`chpl-language-server`](https://chapel-lang.org/docs/main/tools/chpl-language-server/chpl-language-server.html) and [`chplcheck`](https://chapel-lang.org/docs/main/tools/chplcheck/chplcheck.html).
+The codespace includes the Visual Studio Code extension for Chapel, and tools such as
+[`chpl-language-server`](https://chapel-lang.org/docs/main/tools/chpl-language-server/chpl-language-server.html)
+and
+[`chplcheck`](https://chapel-lang.org/docs/main/tools/chplcheck/chplcheck.html).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ CHPL_COMM=gasnet chpl examples/hello4-datapar-dist.chpl
 ```
 
 To avoid having to include `CHPL_COMM` in each compilation command, you can
-export it (you need to do this once per shell session). After this, you can
+`export` it (you need to do this once per shell session). After this, you can
 compile as usual:
 
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,50 @@
 # 'Hello, world!' in Chapel
 
-[Chapel](https://github.com/chapel-lang/chapel/) is a programming language for productive parallel computing. This repository contains starter code for a Chapel project. Please see the [Learning Chapel](https://chapel-lang.org/learning.html) page to learn more of the language's features.
+[Chapel](https://github.com/chapel-lang/chapel/) is a programming language for productive parallel computing. This repository is a simple starting point for Chapel in GitHub Codespaces, with runnable examples in [examples/](examples).
 
-To get started with this template, you can either use [GitHub Codespaces](#using-a-codespace) or [your own machine](#using-your-machine).
+> ⚠️ **Warning:** Codespaces runs in a virtualized environment with shared hardware and a modest core count. Performance and available parallelism in Codespaces are not representative of what you should expect on a native Chapel installation.
 
-For more code samples, consider trying out the [Primers](https://chapel-lang.org/docs/primers/),
-or the [many programs from a past Chapel tutorial](https://github.com/chapel-lang/chapel/tree/main/test/exercises/Oct2023tutorial).
+## Compile And Run In The Terminal
 
-## Using a Codespace
-
-> :warning: Because Codespaces are a virtualized environment running on shared hardware with a modest core count, don't expect parallelism or performance observed here to be reflective of what a native installation of Chapel can achieve.
-
-The `chapel-hello-world` repo includes a `devcontainer.json` file, making it usable from GitHub Codespaces. When viewing this repository from GitHub's UI, click __Use this template > Open in a codespace__ to get started. The codespace includes the Visual Studio Code extension for Chapel, and tools such as [`chpl-language-server`](https://chapel-lang.org/docs/main/tools/chpl-language-server/chpl-language-server.html) and [`chplcheck`](https://chapel-lang.org/docs/main/tools/chplcheck/chplcheck.html).
-
-In the Codespace, compile Chapel programs using the __Terminal__ tab by using the `chpl` compiler:
+Compile and run the main hello-world program:
 
 ```bash
 chpl hello.chpl
 ./hello
 ```
 
-Although the Codespace is set to a single-locale (single-node) mode by default, you can simulate multiple nodes by setting the `CHPL_COMM` environment variable to `gasnet` when compiling.
+Compile and run one of the included examples:
 
 ```bash
-# Compile a program that distributes computation to multiple nodes
-CHPL_COMM=gasnet chpl examples/hello4-datapar-dist.chpl
-
-# Run hello using two simulated nodes
-./hello4-datapar-dist -nl 2 
+chpl examples/hello3-datapar.chpl
+./hello3-datapar
 ```
 
-To avoid having to include `CHPL_COMM` in each compilation command, you can
-`export` it:
+## Simulated Distributed (Multi-Locale) Runs
+
+The Codespace defaults to single-locale mode (`CHPL_COMM=none`).
+
+To simulate multi-locale execution, compile with `CHPL_COMM=gasnet`:
+
+```bash
+CHPL_COMM=gasnet chpl examples/hello4-datapar-dist.chpl
+./hello4-datapar-dist -nl 2
+```
+
+Or export once per shell and compile as usual:
 
 ```bash
 export CHPL_COMM=gasnet
 chpl examples/hello4-datapar-dist.chpl
-./hello4-datapar-dist -nl 2 
+./hello4-datapar-dist -nl 2
 ```
 
-## Using Your Machine
+## Learn More And Try More Programs
 
-Please follow the instructions on the [Download Chapel](https://chapel-lang.org/download.html) page to get set up with the Chapel compiler `chpl`. From there, you can compile and run the `hello.chpl` file in this repository as follows:
+You can copy in additional examples from Chapel Primers or Chapel tutorial/example programs to explore more language features.
 
-```bash
-chpl hello.chpl
-./hello
-```
-
-To make use of multiple nodes (or to simulate multi-node execution), please
-refer to [Multilocale Chapel Execution](https://chapel-lang.org/docs/usingchapel/multilocale.html).
+- [Learning Chapel](https://chapel-lang.org/learning.html)
+- [Chapel Primers](https://chapel-lang.org/docs/primers/)
+- [Chapel tutorial examples](https://github.com/chapel-lang/chapel/tree/main/test/exercises/Oct2023tutorial)
+- [Multilocale Chapel Execution](https://chapel-lang.org/docs/usingchapel/multilocale.html)
+- [Download Chapel](https://chapel-lang.org/download.html)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ CHPL_COMM=gasnet chpl examples/hello4-datapar-dist.chpl
 ./hello4-datapar-dist -nl 2
 ```
 
-To avoid having to include CHPL_COMM in each compilation command, you can export it (you need to do this once per shell session). After this, you can compile as usual:
+To avoid having to include `CHPL_COMM` in each compilation command, you can export it (you need to do this once per shell session). After this, you can compile as usual:
 
 
 ```bash


### PR DESCRIPTION
Since #9 opens the README by default and we expect users to land directly inside codespaces by using the https://codespaces.new/chapel-lang/chapel-hello-world link, we don't need the README to have instructions on how to launch a codespace. 

This PR changes the README to focus on running the examples and pointers to other resources.